### PR TITLE
Use rubocop as default task in Rake

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,6 @@
-require "bundler/gem_tasks"
-task :default => :spec
+require 'bundler/gem_tasks'
+require 'rubocop/rake_task'
+
+task default: :rubocop
+
+RuboCop::RakeTask.new


### PR DESCRIPTION
`rake` コマンドを叩くことで DekaEiwakun 自体を取り締まるようにしました。

これをベースに、別 PR で現状の DekaEiwakun を取り締まるのと、CI 連携する流れにして行きたいと考えています。
