### PR TITLE
Fix Rubocop offenses

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
-require "bundler/setup"
-require "deka_eiwakun"
+require 'bundler/setup'
+require 'deka_eiwakun'
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
@@ -10,5 +10,5 @@ require "deka_eiwakun"
 # require "pry"
 # Pry.start
 
-require "irb"
+require 'irb'
 IRB.start

--- a/deka_eiwakun.gemspec
+++ b/deka_eiwakun.gemspec
@@ -4,22 +4,22 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'deka_eiwakun/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "deka_eiwakun"
+  spec.name          = 'deka_eiwakun'
   spec.version       = DekaEiwakun::VERSION
-  spec.authors       = ["eiwakun"]
-  spec.email         = ["eiwakun@esm.co.jp"]
+  spec.authors       = ['eiwakun']
+  spec.email         = ['eiwakun@esm.co.jp']
 
-  spec.summary       = %q{coding convention in esm}
-  spec.description   = %q{coding convention in esm}
-  spec.homepage      = "https://github.com/esminc/deka_eiwakun"
-  spec.license       = "MIT"
+  spec.summary       = 'coding convention in esm'
+  spec.description   = 'coding convention in esm'
+  spec.homepage      = 'https://github.com/esminc/deka_eiwakun'
+  spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.files         = `git ls-files -z`.split("\x0")
+  spec.bindir        = 'exe'
+  spec.executables   = spec.files.grep(%r{^exe/}) {|f| File.basename(f) }
+  spec.require_paths = ['lib']
 
-  spec.add_dependency "rubocop", "~> 0.37.0"
-  spec.add_development_dependency "bundler", "~> 1.11"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_dependency 'rubocop', '~> 0.37.0'
+  spec.add_development_dependency 'bundler', '~> 1.11'
+  spec.add_development_dependency 'rake', '~> 10.0'
 end

--- a/lib/deka_eiwakun.rb
+++ b/lib/deka_eiwakun.rb
@@ -1,4 +1,4 @@
-require "deka_eiwakun/version"
+require 'deka_eiwakun/version'
 
 module DekaEiwakun
   # Your code goes here...

--- a/lib/deka_eiwakun/version.rb
+++ b/lib/deka_eiwakun/version.rb
@@ -1,3 +1,3 @@
 module DekaEiwakun
-  VERSION = "0.1.0"
+  VERSION = '0.1.0'.freeze
 end


### PR DESCRIPTION
DekaEiwakun 自身を取り締まっておきました :fire:  :gun: :cop: 

`Line is too long` と注意された次の deka_eiwakun.gemspec 一行は、テストコードがないことから結果の変わらない `reject` 以降をざっくりと消すことで短くしておきました。

``` ruby
spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
```

以下、取り締まった内容です。

``` ruby
$ be rake
Running RuboCop...
Inspecting 7 files
C..CCC.

Offenses:

deka_eiwakun.gemspec:7:24: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  spec.name          = "deka_eiwakun"
                       ^^^^^^^^^^^^^^
deka_eiwakun.gemspec:9:25: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  spec.authors       = ["eiwakun"]
                        ^^^^^^^^^
deka_eiwakun.gemspec:10:25: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  spec.email         = ["eiwakun@esm.co.jp"]
                        ^^^^^^^^^^^^^^^^^^^
deka_eiwakun.gemspec:12:24: C: %q-literals should be delimited by ( and ).
  spec.summary       = %q{coding convention in esm}
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
deka_eiwakun.gemspec:12:24: C: Use %q only for strings that contain both single quotes and double quotes.
  spec.summary       = %q{coding convention in esm}
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
deka_eiwakun.gemspec:13:24: C: %q-literals should be delimited by ( and ).
  spec.description   = %q{coding convention in esm}
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
deka_eiwakun.gemspec:13:24: C: Use %q only for strings that contain both single quotes and double quotes.
  spec.description   = %q{coding convention in esm}
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
deka_eiwakun.gemspec:14:24: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  spec.homepage      = "https://github.com/esminc/deka_eiwakun"
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
deka_eiwakun.gemspec:15:24: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  spec.license       = "MIT"
                       ^^^^^
deka_eiwakun.gemspec:17:63: C: Space between { and | detected.
  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
                                                              ^
deka_eiwakun.gemspec:17:81: C: Line is too long. [104/80]
  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
                                                                                ^^^^^^^^^^^^^^^^^^^^^^^^
deka_eiwakun.gemspec:18:24: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  spec.bindir        = "exe"
                       ^^^^^
deka_eiwakun.gemspec:19:52: C: Space between { and | detected.
  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
                                                   ^
deka_eiwakun.gemspec:20:25: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  spec.require_paths = ["lib"]
                        ^^^^^
deka_eiwakun.gemspec:22:23: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  spec.add_dependency "rubocop", "~> 0.37.0"
                      ^^^^^^^^^
deka_eiwakun.gemspec:22:34: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  spec.add_dependency "rubocop", "~> 0.37.0"
                                 ^^^^^^^^^^^
deka_eiwakun.gemspec:23:35: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  spec.add_development_dependency "bundler", "~> 1.11"
                                  ^^^^^^^^^
deka_eiwakun.gemspec:23:46: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  spec.add_development_dependency "bundler", "~> 1.11"
                                             ^^^^^^^^^
deka_eiwakun.gemspec:24:35: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  spec.add_development_dependency "rake", "~> 10.0"
                                  ^^^^^^
deka_eiwakun.gemspec:24:43: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  spec.add_development_dependency "rake", "~> 10.0"
                                          ^^^^^^^^^
bin/console:3:9: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.
require "bundler/setup"
        ^^^^^^^^^^^^^^^
bin/console:4:9: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.
require "deka_eiwakun"
        ^^^^^^^^^^^^^^
bin/console:13:9: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.
require "irb"
        ^^^^^
lib/deka_eiwakun/version.rb:2:13: C: Freeze mutable objects assigned to constants.
  VERSION = "0.1.0"
            ^^^^^^^
lib/deka_eiwakun/version.rb:2:13: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  VERSION = "0.1.0"
            ^^^^^^^
lib/deka_eiwakun.rb:1:9: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.
require "deka_eiwakun/version"
        ^^^^^^^^^^^^^^^^^^^^^^

7 files inspected, 26 offenses detected
RuboCop failed!
```
