### PR TITLE
Remove magic encoding comment

### DIFF
--- a/deka_eiwakun.gemspec
+++ b/deka_eiwakun.gemspec
@@ -1,4 +1,3 @@
-# coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'deka_eiwakun/version'


### PR DESCRIPTION
EOL の Ruby 1.9 系はサポートしてなさそうなため、消しておきました。
