### PR TITLE
allow empty case condition

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -47,3 +47,6 @@ Metrics/AbcSize:
 
 Style/ExtraSpacing:
   Enabled: false
+
+Style/EmptyCaseCondition:
+  Enabled: false

--- a/sample/sample.rb
+++ b/sample/sample.rb
@@ -41,3 +41,13 @@ many_arg_method(
   4,
   5
 )
+
+# 条件無し case
+a = 1
+b = 2
+case
+when a == 1 then true
+when b == 2 then false
+else
+  raise
+end


### PR DESCRIPTION
rubocop 0.40.0 から、条件式無し case がひっかかるようになった。

https://github.com/bbatsov/rubocop/issues/3019

しかし、条件無し case の方が、elsif が連続するより
可読性が上がることがあるため、許可したい