### PR TITLE
Do not specify rubocop version

### DIFF
--- a/deka_eiwakun.gemspec
+++ b/deka_eiwakun.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) {|f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 0.40.0'
+  spec.add_dependency 'rubocop'
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'rake', '~> 10.0'
 end


### PR DESCRIPTION
rubocop のバージョンが上がるたびに gem の更新するのが面倒かつ、これ自体は development dependency 相当で使うものなのでそこまで神経質にならなくてもよさそうな気がしました。