### PR TITLE
0.52.1 まで依存バージョンをあげました

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in deka_eiwakun.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rubocop/rake_task'
 

--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'bundler/setup'
 require 'deka_eiwakun'

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -22,6 +22,9 @@ Naming/VariableName:
 Style/AsciiComments:
   Enabled: false
 
+Style/AsciiComments:
+  Enabled: false
+
 Style/BlockDelimiters:
   EnforcedStyle: semantic
 
@@ -39,6 +42,9 @@ Style/Documentation:
   Enabled: false
 
 Style/EmptyCaseCondition:
+  Enabled: false
+
+Style/FormatStringToken:
   Enabled: false
 
 Style/Lambda:

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -6,6 +6,19 @@ AllCops:
     - 'db/schema.rb'
     - 'vendor/bundle/**/*'
 
+Layout/ExtraSpacing:
+  Enabled: false
+
+Layout/SpaceInsideBlockBraces:
+  SpaceBeforeBlockParameters: false
+
+Layout/SpaceInsideHashLiteralBraces:
+  EnforcedStyle: no_space
+
+Layout/VariableName:
+  EnforcedStyle: snake_case
+  Enabled: true
+
 Style/AsciiComments:
   Enabled: false
 
@@ -28,9 +41,6 @@ Style/Documentation:
 Style/EmptyCaseCondition:
   Enabled: false
 
-Style/ExtraSpacing:
-  Enabled: false
-
 Style/Lambda:
   Enabled: false
 
@@ -42,16 +52,6 @@ Style/PercentLiteralDelimiters:
     '%r': '||'
     '%w': '()'
     '%W': '()'
-
-Style/SpaceInsideBlockBraces:
-  SpaceBeforeBlockParameters: false
-
-Style/SpaceInsideHashLiteralBraces:
-  EnforcedStyle: no_space
-
-Style/VariableName:
-  EnforcedStyle: snake_case
-  Enabled: true
 
 Metrics/AbcSize:
   Exclude:

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -15,7 +15,7 @@ Layout/SpaceInsideBlockBraces:
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
 
-Layout/VariableName:
+Naming/VariableName:
   EnforcedStyle: snake_case
   Enabled: true
 

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -34,6 +34,15 @@ Style/ExtraSpacing:
 Style/Lambda:
   Enabled: false
 
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    default: '()'
+    '%i': '()'
+    '%I': '()'
+    '%r': '||'
+    '%w': '()'
+    '%W': '()'
+
 Style/SpaceInsideBlockBraces:
   SpaceBeforeBlockParameters: false
 

--- a/deka_eiwakun.gemspec
+++ b/deka_eiwakun.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'deka_eiwakun/version'

--- a/deka_eiwakun.gemspec
+++ b/deka_eiwakun.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) {|f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 0.40.0'
+  spec.add_dependency 'rubocop', '~> 0.52.1'
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'rake', '~> 10.0'
 end

--- a/deka_eiwakun.gemspec
+++ b/deka_eiwakun.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.bindir        = 'exe'
-  spec.executables   = spec.files.grep(%r{^exe/}) {|f| File.basename(f) }
+  spec.executables   = spec.files.grep(%r|^exe/|) {|f| File.basename(f) }
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rubocop', '~> 0.52.1'

--- a/lib/deka_eiwakun.rb
+++ b/lib/deka_eiwakun.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'deka_eiwakun/version'
 
 module DekaEiwakun

--- a/lib/deka_eiwakun.rb
+++ b/lib/deka_eiwakun.rb
@@ -1,5 +1,4 @@
 require 'deka_eiwakun/version'
 
 module DekaEiwakun
-  # Your code goes here...
 end

--- a/lib/deka_eiwakun/version.rb
+++ b/lib/deka_eiwakun/version.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+
+# rubocop:disable Style/RedundantFreeze
 module DekaEiwakun
   VERSION = '0.4.0'.freeze
 end
+# rubocop:enable Style/RedundantFreeze

--- a/sample/sample.rb
+++ b/sample/sample.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # ブロック
 ## 一行ブロック
 


### PR DESCRIPTION
以前の 0.40 以降の Style に関する変更をみて気になったところ、手元のプロジェクトでひっかかったところのルールに対して変更を加えています。

気になったところはご意見ください。

| ver  | style name                                       |       default                   | change default?   |
| ---- | ------------------------------------------------ | ------------------------------- | ----------------- |
| 0.41 | Style/AlignParameters                            | Enabled(with_first_parameter)   | no                |
| 0.41 | Style/ImplicitRuntimeError                       | Disabled                        | no                |
| 0.41 | Style/EachForSimpleLoop                          | Enabled                         | no                |
| 0.41 | Style/ModuleFunction                             | Enabled(module_function)        | no                |
| 0.41 | Style/EachForSimpleLoop                          | Enabled                         | no                |
| 0.41 | Style/SpaceInsideArrayPercentLiteral             | Enabled                         | no                |
| 0.41 | Style/SpaceInsidePercentLiteralDelimiters        | Enabled                         | no                |
| 0.41 | Style/NumericLiteralPrefix                       | Enabled(zero_with_o)            | no                |
| 0.41 | Style/MultilineMethodCallIndentation             | Enabled(aligned)                | no                | ※
| 0.42 | Style/EachWithObject                             | Enabled                         | no                | ※
| 0.42 | Style/TernaryParentheses                         | Enabled(require_no_parentheses) | no                | ※
| 0.43 | Style/DocumentationMethod                        | Disabled                        | no                |
| 0.43 | Style/SafeNavigation                             | Enabled                         | no                |
| 0.44 | Style/EmptyLinesAroundClassBody                  | Enabled(no_empty_lines)         | no                |
| 0.44 | Style/EmptyLinesAroundModuleBody                 | Enabled(no_empty_lines)         | no                |
| 0.44 | Style/PreferredHashMethods                       | Enabled(short)                  | no                |
| 0.44 | Style/MultilineMemoization                       |                                 | no                |
| 0.45 | Style/SpaceInLambdaLiteral                       |                                 | no                |
| 0.45 | Style/EmptyExpression                            |                                 | no                |
| 0.46 | Style/EmptyMethod                                |                                 | no                |
| 0.46 | Style/EmptyLiteral                               |                                 | no                |
| 0.47 | Style/FrozenStringLiteralComment                 |                                 | no                | ※
| 0.47 | Style/ConditionalAssignment                      |                                 | no                |
| 0.47 | Style/MethodCallWithArgsParentheses              |                                 | no                |
| 0.48 | Style/NegatedIf                                  | Enabled(both)                   | no                |
| 0.48 | Style/EmptyLineBetweenDefs                       | Enabled                         | no                |
| 0.48 | Style/NumericLiterals                            | Enabled                         | no                |
| 0.48 | Style/EmptyLineAfterMagicComment                 | Enabled                         | no                | ※
| 0.48 | Style/EndOfLine                                  | Enabled(native)                 | no                |
| 0.48 | Style/MixinGrouping                              | Enabled(separeted)              | no                |
| 0.48 | Style/EmptyLinesAroundBeginBody                  | Enabled                         | no                |
| 0.48 | Style/EmptyLinesAroundExceptionHandlingKeywords  | Enabled                         | no                |
| 0.48 | Style/MultilineMemoization                       | Enabled(keyword)                | no                |
| 0.48 | Style/IndentHeredoc                              | Enabled(auto_detection)         | no                | ※
| 0.48 | Style/InverseMethods                             | Enabled                         | no                |
| 0.48 | Style/PercentLiteralDelimiters                   | Enabled                         | '()', %r は '||'  |
| 0.48 | Style/MethodCallWithArgsParentheses              | Disabled                        | no                |
| 0.49 | Style/FormatStringToken                          | Enabled                         | no                | ※
| 0.49 | Style/YodaCondition                              | Enabled                         | no                |
| 0.49 | Style/MultipleComparison                         | Enabled                         | no                |
| 0.50 | Style/SpaceBeforeBlockBraces                     | Enabled(space)                  | no                |
| 0.50 | Style/RedundantConditional                       | Enabled                         | no                |
| 0.50 | Style/HeredocDelimiterNaming                     | Enabled                         | no                |
| 0.50 | Style/Dir                                        | Enabled                         | no                |
| 0.50 | Style/HeredocDelimiterCase                       | Enabled(uppercase)              | no                |
| 0.50 | Style/TrailingUnderscoreVariable                 | Enabled                         | no                | ※
| 0.50 | Style/NestedParenthesizedCalls                   | Enabled                         | no                |
| 0.50 | Style/ReturnNil                                  | Disabled                        | no                | ※
| 0.50 | Style/MinMax                                     | Enabled                         | no                |
| 0.51 | Style/StderrPuts                                 | Enabled                         | no                |
| 0.51 | Style/CommentedKeyword                           | Enabled                         | no                |
| 0.51 | Style/MixinUsage                                 | Enabled                         | no                |
| 0.51 | Style/DateTime                                   | Enabled                         | no                |
| 0.52 | Layout/ClassStructure                            | Disabled                        | xxxx              | ※
| 0.52 | Rails/InverseOf                                  | Enabled                         | no                |
| 0.52 | Layout/SpaceInsideReferenceBrackets              | Enabled                         | no                |
| 0.52 | Layout/SpaceInsideArrayLiteralBracket            | Enabled                         | no                |
| 0.52 | Style/TrailingBodyOnMethodDefinition             | Enabled                         | no                |
| 0.52 | Style/TrailingMethodEndStatment                  | Enabled                         | no                |
| 0.52 | Layout/EmptyLinesAroundArguments                 | Enabled                         | no                |
| 0.52 | Style/StringHashKeys                             | Disabled                        | no                |
| 0.52 | Style/RandomWithOffset                           | Enabled                         | no                |
| 0.52 | Lint/ShadowedArgument                            | Enabled                         | no                |
| 0.52 | Lint/MissingCopEnableDirective                   | Enabled                         | no                |
| 0.52 | Style/AsciiComments                              | Enabled                         | disabled          |
| 0.52 | Style/EmptyBlockParameter                        | Enabled                         | no                |
| 0.52 | Style/EmptyLambdaParameter                       | Enabled                         | no                |
| 0.52 | Style/FormatStringToken                          | Enabled                         | disabled          |
| 0.52 | Rails/CreateTableWithTimestamps                  | Enabled                         | no                |
| 0.52 | Style/ColonMethodDefinition                      | Enabled                         | no                |
| 0.52 | Rails/RedundantReceiverInWithOptions             | Enabled                         | no                |
| 0.52 | Rails/LexicallyScopedActionFilter                | Enabled                         | no                |
| 0.52 | Style/EvalWithLocation                           | Enabled                         | no                |
| 0.52 | Rails/Presence                                   | Enabled                         | no                |


以前の deka_eiwakun バージョンに .rubocop.yml を上書きした設定で移動しているものは直しています。

Style/ExtraSpacing has the wrong namespace - should be Layout
Style/SpaceInsideBlockBraces has the wrong namespace - should be Layout
Style/SpaceInsideHashLiteralBraces has the wrong namespace - should be Layout
Style/VariableName has the wrong namespace - should be Naming