### PR TITLE
Update rubocop gem to 0.53.0

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -15,6 +15,12 @@ Layout/SpaceInsideBlockBraces:
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
 
+Naming/UncommunicativeBlockParamName:
+  Enabled: false
+
+Naming/UncommunicativeMethodParamName:
+  Enabled: false
+
 Naming/VariableName:
   EnforcedStyle: snake_case
   Enabled: true

--- a/deka_eiwakun.gemspec
+++ b/deka_eiwakun.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r|^exe/|) {|f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 0.52.1'
+  spec.add_dependency 'rubocop', '~> 0.53.0'
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'rake', '~> 10.0'
 end

--- a/deka_eiwakun.gemspec
+++ b/deka_eiwakun.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'deka_eiwakun/version'
 

--- a/lib/deka_eiwakun/version.rb
+++ b/lib/deka_eiwakun/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DekaEiwakun
-  VERSION = '0.5.0'.freeze
+  VERSION = '0.5.0'
 end

--- a/lib/deka_eiwakun/version.rb
+++ b/lib/deka_eiwakun/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
+
 module DekaEiwakun
   VERSION = '0.5.0'.freeze
 end
-# rubocop:enable Style/RedundantFreeze

--- a/lib/deka_eiwakun/version.rb
+++ b/lib/deka_eiwakun/version.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
-
-# rubocop:disable Style/RedundantFreeze
 module DekaEiwakun
   VERSION = '0.5.0'.freeze
 end


### PR DESCRIPTION
new feature から今回の更新分をチェックしています。

| version    | style name | default | change? |
| ------ | ---- |-------- | ------- |
| 0.53.0 | Style/EmptyLineAfterGuardClause       | Disabled | no  |
| 0.53.0 | Naming/MemoizedInstanceVariableName   | Enabled  | no  |
| 0.53.0 | Layout/EmptyLinesAroundClassBody      | Enabled  | no  |
| 0.53.0 | Style/ExpandPathArguments             | Enabled  | no  |
| 0.53.0 | Lint/OrderedMagicComments             | Enabled  | no  |
| 0.53.0 | Layout/EmptyComment                   | Enabled  | no |
| 0.53.0 | Style/ModuleFunction                  | Enabled  | no  |
| 0.53.0 | Layout/SpaceInsideReferenceBrackets   | Enabled  | no  |
| 0.53.0 | Style/TrailingCommaInHashLiteral      | Enabled  | no  |
| 0.53.0 | Style/TrailingCommaInArrayLiteral     | Enabled  | no  |
| 0.53.0 | Style/TrailingBodyOnModule            | Enabled  | no  |
| 0.53.0 | Style/TrailingBodyOnClass             | Enabled  | no  |
| 0.53.0 | Lint/BigDecimalNew                    | Enabled  | no  |
| 0.53.0 | Lint/UnneededCopEnableDirective       | Enabled  | no  |
| 0.53.0 | Naming/UncommunicativeMethodParamName | Enabled  | **yes** |
| 0.53.0 | Naming/UncommunicativeBlockParamName  | Enabled  | **yes** |

### default 設定から変更した rule

- [Naming/UncommunicativeBlockParamName](http://rubocop.readthedocs.io/en/latest/cops_naming/#naminguncommunicativeblockparamname): enable -> disable
- [Naming/UncommunicativeMethodParamName](http://rubocop.readthedocs.io/en/latest/cops_naming/#naminguncommunicativemethodparamname): enable -> disable

### disabled にした理由

block parameter に `f`, `(k, v)` は一般的に使うと思われるのでいちいち whitelist 化していられない、method parameter も override して使わない場合に `_` を使ったり、exception を示す `e`を使う場面が多いため。
(個人的な感情論ですが、) exception という文字が例外の宣言とともに検索にかかってしまう、exp はexpression のイメージが強いので、例外を示すときは e を好んで使っています。